### PR TITLE
GistID is no longer a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function adjustHeightWhenComplete(myFrame, myDoc) {
 var GistEmbed = React.createClass({
   displayName: 'GistEmbed',
   propTypes: {
-    gistId: PropTypes.number.isRequired
+    gistId: PropTypes.string.isRequired
   },
   componentDidMount: function() {
 


### PR DESCRIPTION
Changed the proptype to string instead of number since ids look like this now:
`ce319b53db4de0b9f3a0fc90379f95a3`